### PR TITLE
Fixed Issue 15: Task not working on legacy agent.

### DIFF
--- a/Frends.Community.Postgre/Definitions/Extensions.cs
+++ b/Frends.Community.Postgre/Definitions/Extensions.cs
@@ -118,7 +118,7 @@ namespace Frends.Community.Postgre.Definitions
             using (var reader = await command.ExecuteReaderAsync(cancellationToken))
             using (var writer =  new StringWriter() as TextWriter)
             {
-                await DataReaderToCsvString(reader, writer, output.CsvOptions, cancellationToken);
+                await DataReaderToCsvString((NpgsqlDataReader)reader, writer, output.CsvOptions, cancellationToken);
                 return writer.ToString();
             }
         }

--- a/Frends.Community.Postgre/Frends.Community.Postgre.csproj
+++ b/Frends.Community.Postgre/Frends.Community.Postgre.csproj
@@ -9,7 +9,7 @@
     <IncludeSource>true</IncludeSource>
     <PackageTags>Frends</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>2.1.0</Version>
+    <Version>2.1.1</Version>
   </PropertyGroup>
 
   <ItemGroup>
@@ -21,7 +21,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <PackageReference Include="Npgsql" Version="4.1.5" />
+    <PackageReference Include="Npgsql" Version="4.0.10" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
 	<PackageReference Include="CsvHelper" Version="12.2.2" />
 	<PackageReference Include="System.Text.Encoding.CodePages" Version="7.0.0" />

--- a/README.md
+++ b/README.md
@@ -193,3 +193,4 @@ NOTE: Be sure to merge the latest from "upstream" before making a pull request!
 | 2.0.0 | Refactored the task and added new task ExecuteQueryToFile which handles all three datatypes. |
 | 2.0.1 | Fixed issue with ExecuteQueryToFile Result's Rows value not being implemented correctly and updated the npsql dependency version to 6.0.5. |
 | 2.1.0 | Rollbacked the npgsql package version and added more dependencies to the csproj file for the task to work on legacy Agents |
+| 2.1.1 | Rollbacked the npgsql package version for the task to work on legacy Agents |


### PR DESCRIPTION
Fix for the error:
'Could not load file or assembly 'System.Net.Sockets, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies. The system cannot find the file specified.'

Solution was a rollback npqsql version to 4.0.10.